### PR TITLE
Added showChat boolean to Commons entity

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -30,6 +30,9 @@ public class Commons {
     private LocalDateTime startingDate;
     private LocalDateTime lastDate;
     private boolean showLeaderboard;
+
+    @Builder.Default
+    private boolean showChat = true;
     
     private int capacityPerUser;
     private int carryingCapacity;


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add the showChat field to the Commons entity. This field is currently set to true by default when a new commons is created, and is used nowhere in the code.

NOTE: This PR will break all existing data by putting it into a bad state where it has an empty show_chat property.

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #11 
