### PR TITLE
Ritu Leaderboard Whitespace

### DIFF
--- a/frontend/src/main/pages/LeaderboardPage.css
+++ b/frontend/src/main/pages/LeaderboardPage.css
@@ -1,0 +1,8 @@
+.board {
+    width: 60%;
+    margin: auto;
+}
+
+.name {
+    text-align: center;
+}

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -13,6 +13,8 @@ import Background from "../../assets/PlayPageBackground.png";
 import { useNavigate } from "react-router-dom";
 import { Button } from "react-bootstrap";
 
+import "./LeaderboardPage.css"
+
 export default function LeaderboardPage() {
     const { commonsId } = useParams();
     const { data: currentUser } = useCurrentUser();
@@ -66,8 +68,8 @@ export default function LeaderboardPage() {
             }}
         >
             <BasicLayout>
-                <div className="pt-2">
-                    <h1>Leaderboard</h1>
+                <div className="pt-2 board">
+                    <h1 className="name">Leaderboard</h1>
                     {showLeaderboard ? (
                         <>
                             <LeaderboardTable


### PR DESCRIPTION
In this PR, the leaderboard is now centered and the file LeaderboardPage.css has been created.

<img width="1440" alt="Screenshot 2024-03-05 at 5 12 33 PM" src="https://github.com/ucsb-cs156-w24/proj-happy-cows-w24-4pm-2/assets/61635695/387b147b-26b3-49a3-9be9-d92ec2cbf664">

Should I also move the button to make it closer to the center of the page?

Closes #2 
