### PR TITLE
Enabled admins to set showChat in API

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -126,7 +126,7 @@ public class CommonsController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/update")
     public ResponseEntity<String> updateCommons(
-            @Parameter(name="commons identifier") @RequestParam long id,
+            @Parameter(name="id") @RequestParam long id,
             @Parameter(name="request body") @RequestBody CreateCommonsParams params
     ) {
         Optional<Commons> existing = commonsRepository.findById(id);
@@ -149,6 +149,7 @@ public class CommonsController extends ApiController {
         updated.setStartingDate(params.getStartingDate());
         updated.setLastDate(params.getLastDate());
         updated.setShowLeaderboard(params.getShowLeaderboard());
+        updated.setShowChat(params.getShowChat());
         updated.setDegradationRate(params.getDegradationRate());
         updated.setCapacityPerUser(params.getCapacityPerUser());
         updated.setCarryingCapacity(params.getCarryingCapacity());
@@ -216,6 +217,7 @@ public class CommonsController extends ApiController {
                 .lastDate(params.getLastDate())
                 .degradationRate(params.getDegradationRate())
                 .showLeaderboard(params.getShowLeaderboard())
+                .showChat(params.getShowChat())
                 .capacityPerUser(params.getCapacityPerUser())
                 .carryingCapacity(params.getCarryingCapacity());
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -24,6 +24,8 @@ public class CreateCommonsParams {
     private LocalDateTime lastDate;
     @Builder.Default
     private Boolean showLeaderboard = false;
+    @Builder.Default
+    private Boolean showChat = true;
     @NumberFormat
     private int capacityPerUser;
     @NumberFormat

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -109,6 +109,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
@@ -123,6 +124,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant.name())
@@ -162,6 +164,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -174,6 +177,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -214,6 +218,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(0)
                 .showLeaderboard(false)
+                .showChat(true)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -226,6 +231,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(0)
                 .showLeaderboard(false)
+                .showChat(true)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -323,6 +329,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .startingDate(someTime)
                 .lastDate(someTime)
+                .showChat(true)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .capacityPerUser(10)
@@ -338,6 +345,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .startingDate(someTime)
                 .lastDate(someTime)
+                .showChat(true)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
                 .capacityPerUser(10)
@@ -366,6 +374,8 @@ public class CommonsControllerTests extends ControllerTestCase {
         commons.setDegradationRate(parameters.getDegradationRate());
         parameters.setShowLeaderboard(false);
         commons.setShowLeaderboard(parameters.getShowLeaderboard());
+        parameters.setShowChat(false);
+        commons.setShowChat(parameters.getShowChat());
         parameters.setCapacityPerUser(12);
         commons.setCapacityPerUser(parameters.getCapacityPerUser());
         parameters.setCarryingCapacity(123);
@@ -406,6 +416,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -418,6 +429,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(50.0)
                 .showLeaderboard(true)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
@@ -460,6 +472,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -472,6 +485,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -530,6 +544,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -542,6 +557,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(8.49)
                 .showLeaderboard(false)
+                .showChat(false)
                 .capacityPerUser(10)
                 .carryingCapacity(100)
                 .build();
@@ -787,6 +803,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingDate(someTime)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
 
@@ -945,6 +962,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
 
@@ -967,6 +985,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
         
@@ -989,6 +1008,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
 
@@ -1011,6 +1031,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(-1.0)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
         
@@ -1033,6 +1054,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(0)
                 .build();
 
@@ -1059,6 +1081,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(0.0)
                 .degradationRate(0.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(1)
                 .build();
 
@@ -1087,6 +1110,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .showChat(false)
         .carryingCapacity(100)
         .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
         .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
@@ -1103,6 +1127,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
 
@@ -1125,6 +1150,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
 
@@ -1147,6 +1173,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
 
@@ -1169,6 +1196,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(-1.0)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(100)
                 .build();
 
@@ -1191,6 +1219,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(1020.10)
                 .degradationRate(50.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(0)
                 .build();
 
@@ -1220,6 +1249,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .showChat(false)
         .carryingCapacity(100)
         .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
         .belowCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Linear)
@@ -1236,6 +1266,7 @@ public class CommonsControllerTests extends ControllerTestCase {
                 .startingBalance(0.0)
                 .degradationRate(0.0)
                 .showLeaderboard(false)
+                .showChat(false)
                 .carryingCapacity(1)
                 .build();
 
@@ -1265,6 +1296,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .showChat(false)
         .capacityPerUser(5)
         .carryingCapacity(10)
         .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
@@ -1288,6 +1320,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .showChat(false)
         .capacityPerUser(50)
         .carryingCapacity(10)
         .aboveCapacityHealthUpdateStrategy(CowHealthUpdateStrategies.Constant)
@@ -1298,7 +1331,6 @@ public class CommonsControllerTests extends ControllerTestCase {
 
         assertEquals(100, commonsPlus.getEffectiveCapacity());
     }
-
 
 }
 


### PR DESCRIPTION
## Overview
Enabled admins to set showChat via the API. Also fixed a possible bug in swagger that used the wrong endpoint for put.

## Validation (Optional)
Manually tested in localhost, also deployed at http://hc-kyle-dev.dokku-02.cs.ucsb.edu

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #21
